### PR TITLE
fix(docs): corrige la sintaxis del filtro de fecha en la plantilla de…

### DIFF
--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -286,7 +286,7 @@ nav_order: 6
 All notable changes to this project will be documented in this file.
 
 {% for release in releases %}
-## [{{ release.tag_name }}] - {{ release.published_at | date:"%Y-%m-%d" }}
+## [{{ release.tag_name }}] - {{ release.published_at[:10] }}
 
 {{ release.body }}
 {% endfor %}


### PR DESCRIPTION
…l changelog

El filtro 'date' no es un filtro estándar de Jinja2 y causaba un error de sintaxis durante la generación de la documentación.

Se reemplaza el filtro por un 'slicing' de la cadena de fecha para extraer la parte correspondiente a YYYY-MM-DD, solucionando el fallo en el pipeline de CI.