### PR TITLE
fix(ci): robustece el push a la wiki y corrige el despliegue de pages

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -177,7 +177,7 @@ jobs:
           git commit -m "Update wiki documentation from PR #${{ github.event.pull_request.number || 'direct-push' }}" || echo "No changes to commit"
           
           if [[ "${{ github.event.pull_request.head.repo.full_name }}" == "${{ github.repository }}" ]] || [[ "${{ github.event_name }}" == "push" ]]; then
-            git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git main || echo "Wiki push failed"
+            git push --set-upstream https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git main || echo "Wiki push failed"
           fi
 
       - name: Upload artifacts


### PR DESCRIPTION
Se mejora el comando 'git push' en el workflow para asegurar que la rama 'main' de la wiki se establezca correctamente en el primer push.

Este cambio también requiere una modificación manual en la configuración del repositorio para que GitHub Pages utilice 'GitHub Actions' como fuente de despliegue, solucionando así el error de build de Jekyll.