### PR TITLE
chore(ci): expone errores en el push a la wiki para diagnóstico

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -177,7 +177,7 @@ jobs:
           git commit -m "Update wiki documentation from PR #${{ github.event.pull_request.number || 'direct-push' }}" || echo "No changes to commit"
           
           if [[ "${{ github.event.pull_request.head.repo.full_name }}" == "${{ github.repository }}" ]] || [[ "${{ github.event_name }}" == "push" ]]; then
-            git push --set-upstream https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git main || echo "Wiki push failed"
+            git push --set-upstream https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git main
           fi
 
       - name: Upload artifacts


### PR DESCRIPTION
Se elimina el supresor de errores ('|| echo') del comando 'git push' a la wiki.

Este cambio es para depuración y hará que el pipeline falle si el push a la wiki no tiene éxito, permitiendo ver el mensaje de error real y diagnosticar por qué no se está actualizando.