### PR TITLE
fix(ci): corrige la rama de despliegue de la wiki a master

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -177,7 +177,7 @@ jobs:
           git commit -m "Update wiki documentation from PR #${{ github.event.pull_request.number || 'direct-push' }}" || echo "No changes to commit"
           
           if [[ "${{ github.event.pull_request.head.repo.full_name }}" == "${{ github.repository }}" ]] || [[ "${{ github.event_name }}" == "push" ]]; then
-            git push --set-upstream https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git main
+            git push --set-upstream https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git master
           fi
 
       - name: Upload artifacts


### PR DESCRIPTION
El pipeline fallaba porque intentaba hacer push a la rama 'main' del repositorio de la wiki, cuando la rama por defecto es 'master'.

Se corrige el comando 'git push' para que apunte a la rama correcta, solucionando el error de despliegie de la wiki.