### PR TITLE
feat(docs): añade diagramas de secuencia y estado a la documentación

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -75,6 +75,8 @@ jobs:
               </div>
               <div id="stats" class="stats"></div>
               <div id="architecture" class="section"></div>
+              <div id="sequence-diagram" class="section"></div>
+              <div id="state-diagram" class="section"></div>
               <div id="dependencies" class="section">
                   <h2>🌳 Grafo de Dependencias</h2>
                   <p>El siguiente es el árbol de dependencias completo del proyecto, generado por Maven.</p>
@@ -137,6 +139,24 @@ jobs:
                   </div>
               `;
               document.getElementById('architecture').innerHTML = architectureHTML;
+
+              // --- Sequence Diagram ---
+              fetch('diagrams/sequence-registration.mmd')
+                  .then(response => response.text())
+                  .then(data => {
+                      const sequenceContainer = document.getElementById('sequence-diagram');
+                      sequenceContainer.innerHTML = '<h2>🔄 Diagrama de Secuencia: Registro de Servicio</h2><div class="mermaid">' + data + '</div>';
+                      mermaid.init(undefined, sequenceContainer.querySelector('.mermaid'));
+                  });
+
+              // --- State Diagram ---
+              fetch('diagrams/state-lifecycle.mmd')
+                  .then(response => response.text())
+                  .then(data => {
+                      const stateContainer = document.getElementById('state-diagram');
+                      stateContainer.innerHTML = '<h2>🚦 Diagrama de Estado: Ciclo de Vida del Servicio</h2><div class="mermaid">' + data + '</div>';
+                      mermaid.init(undefined, stateContainer.querySelector('.mermaid'));
+                  });
           
               // --- Milestones ---
               let milestonesHTML = '<h2>🎯 Milestones</h2>';

--- a/docs/diagrams/sequence-registration.mmd
+++ b/docs/diagrams/sequence-registration.mmd
@@ -1,0 +1,14 @@
+sequenceDiagram
+    participant UserSvc as Servicio de Usuarios
+    participant EurekaSvc as Eterea Eureka
+    participant Gateway as API Gateway
+
+    UserSvc->>+EurekaSvc: 1. Petición de Registro (REGISTER)
+    EurekaSvc-->>-UserSvc: 2. Registro Exitoso (200 OK)
+
+    loop Heartbeats
+        UserSvc->>EurekaSvc: 3. Envío de Heartbeat periódico
+    end
+
+    Gateway->>+EurekaSvc: 4. Petición de Registro de Servicios (FETCH)
+    EurekaSvc-->>-Gateway: 5. Devuelve lista de servicios (incluye UserSvc)

--- a/docs/diagrams/state-lifecycle.mmd
+++ b/docs/diagrams/state-lifecycle.mmd
@@ -1,0 +1,9 @@
+stateDiagram-v2
+    [*] --> STARTING: Al arrancar
+    STARTING --> UP: Registro exitoso
+    UP --> UP: Heartbeat recibido
+    UP --> DOWN: Heartbeat perdido (timeout)
+    DOWN --> UP: Heartbeat recuperado
+    UP --> OUT_OF_SERVICE: Des-registro manual
+    OUT_OF_SERVICE --> [*]: Eliminado
+    DOWN --> [*]: Eliminado por inactividad


### PR DESCRIPTION
Se enriquece la documentación autogenerada con diagramas visuales para clarificar los flujos de trabajo clave del servicio.

- Se crea un directorio 'docs/diagrams' para almacenar los ficheros fuente de Mermaid.

- Se añade un diagrama de secuencia que ilustra el proceso de registro de un nuevo servicio.

- Se añade un diagrama de estado que muestra el ciclo de vida de un servicio en Eureka.

- El pipeline se actualiza para leer estos ficheros y renderizarlos en la página principal de la documentación.