### PR TITLE
fix(docs): genera dinámicamente la URL de GitHub Pages en la wiki

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -225,7 +225,7 @@ jobs:
 
           Toda la **documentación detallada, interactiva y actualizada** se encuentra en nuestro sitio de **GitHub Pages**.
 
-          ## ➡️ [Acceder a la Documentación Principal](https://eterea.github.io/eureka-service/)
+          ## ➡️ [Acceder a la Documentación Principal](https://$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]').github.io/$(echo ${{ github.repository }} | cut -d'/' -f2)/)
 
           ---
 


### PR DESCRIPTION
Se corrige el enlace roto en la wiki que apuntaba a la documentación principal.

- Se utiliza la variable de entorno 'github.repository' para construir la URL de GitHub Pages de forma dinámica.

- Esto asegura que el enlace siempre sea correcto, independientemente del nombre del propietario o del repositorio.